### PR TITLE
Harden auth storage access and improve login handling

### DIFF
--- a/Shopping App/src/components/LoginPage.tsx
+++ b/Shopping App/src/components/LoginPage.tsx
@@ -12,13 +12,16 @@ interface LoginPageProps {
 
 export default function LoginPage({ onBack, onMenuClick, cartCount, totalBambicoins, onLoginSuccess }: LoginPageProps) {
   const [isLogin, setIsLogin] = useState(true);
+  const [identifier, setIdentifier] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  
+  const [needsOtp, setNeedsOtp] = useState(false);
+  const [otpCode, setOtpCode] = useState('');
+
   const { login, register } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -27,12 +30,35 @@ export default function LoginPage({ onBack, onMenuClick, cartCount, totalBambico
     setIsLoading(true);
 
     try {
-      let success = false;
-      
       if (isLogin) {
-        success = await login(email, password);
-        if (!success) {
-          setError('Неверный email или пароль');
+        if (!identifier.trim()) {
+          setError('Введите email или номер телефона');
+          setIsLoading(false);
+          return;
+        }
+
+        const result = await login(identifier, password, needsOtp ? otpCode : undefined);
+
+        if (result.success) {
+          setNeedsOtp(false);
+          setOtpCode('');
+          setIdentifier('');
+          setPassword('');
+          if (onLoginSuccess) {
+            onLoginSuccess();
+          } else {
+            onBack();
+          }
+          return;
+        }
+
+        if (result.requiresOtp) {
+          setNeedsOtp(true);
+          setError(result.message || 'Введите одноразовый код из приложения-аутентификатора');
+        } else {
+          setNeedsOtp(false);
+          setOtpCode('');
+          setError(result.message || 'Неверный email/телефон или пароль');
         }
       } else {
         if (!name.trim()) {
@@ -40,21 +66,26 @@ export default function LoginPage({ onBack, onMenuClick, cartCount, totalBambico
           setIsLoading(false);
           return;
         }
-        success = await register(email, password, name, phone);
+        const success = await register(email, password, name, phone);
         if (!success) {
-          setError('Пользователь с таким email уже существует');
-        }
-      }
-      
-      if (success) {
-        // Успешный вход/регистрация
-        if (onLoginSuccess) {
-          onLoginSuccess();
+          setError('Пользователь с таким email или телефоном уже существует');
         } else {
-          onBack();
+          setIdentifier('');
+          setPassword('');
+          setName('');
+          setPhone('');
+          setEmail('');
+          if (onLoginSuccess) {
+            onLoginSuccess();
+          } else {
+            onBack();
+          }
+          setIsLoading(false);
+          return;
         }
       }
     } catch (error) {
+      console.error('Ошибка при обработке формы входа/регистрации:', error);
       setError('Произошла ошибка. Попробуйте еще раз.');
     } finally {
       setIsLoading(false);
@@ -62,21 +93,33 @@ export default function LoginPage({ onBack, onMenuClick, cartCount, totalBambico
   };
 
   const handleDemoLogin = async () => {
-    setEmail('demo@example.com');
+    setIdentifier('demo@example.com');
     setPassword('demo123');
     setIsLoading(true);
-    
-    const success = await login('demo@example.com', 'demo123');
-    if (success) {
-      if (onLoginSuccess) {
-        onLoginSuccess();
+
+    try {
+      const result = await login('demo@example.com', 'demo123', needsOtp ? otpCode : undefined);
+
+      if (result.success) {
+        setNeedsOtp(false);
+        setOtpCode('');
+        if (onLoginSuccess) {
+          onLoginSuccess();
+        } else {
+          onBack();
+        }
+      } else if (result.requiresOtp) {
+        setNeedsOtp(true);
+        setError(result.message || 'Введите код из приложения-аутентификатора для демо-аккаунта');
       } else {
-        onBack();
+        setError(result.message || 'Ошибка демо-входа');
       }
-    } else {
-      setError('Ошибка демо-входа');
+    } catch (demoError) {
+      console.error('Ошибка демо-входа:', demoError);
+      setError('Не удалось выполнить демо-вход. Попробуйте еще раз.');
+    } finally {
+      setIsLoading(false);
     }
-    setIsLoading(false);
   };
 
   return (
@@ -180,19 +223,35 @@ export default function LoginPage({ onBack, onMenuClick, cartCount, totalBambico
               </div>
             )}
 
-            <div>
-              <label className="block text-[14px] font-medium text-gray-700 mb-2">
-                Email *
-              </label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#8B4513] focus:border-transparent outline-none"
-                placeholder="example@email.com"
-                required
-              />
-            </div>
+            {isLogin ? (
+              <div>
+                <label className="block text-[14px] font-medium text-gray-700 mb-2">
+                  Email или телефон *
+                </label>
+                <input
+                  type="text"
+                  value={identifier}
+                  onChange={(e) => setIdentifier(e.target.value)}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#8B4513] focus:border-transparent outline-none"
+                  placeholder="example@email.com или +7 (999) 123-45-67"
+                  required={isLogin}
+                />
+              </div>
+            ) : (
+              <div>
+                <label className="block text-[14px] font-medium text-gray-700 mb-2">
+                  Email *
+                </label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#8B4513] focus:border-transparent outline-none"
+                  placeholder="example@email.com"
+                  required
+                />
+              </div>
+            )}
 
             <div>
               <label className="block text-[14px] font-medium text-gray-700 mb-2">
@@ -208,6 +267,27 @@ export default function LoginPage({ onBack, onMenuClick, cartCount, totalBambico
                 minLength={6}
               />
             </div>
+
+            {needsOtp && (
+              <div>
+                <label className="block text-[14px] font-medium text-gray-700 mb-2">
+                  Код подтверждения *
+                </label>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={otpCode}
+                  onChange={(e) => setOtpCode(e.target.value.replace(/[^0-9]/g, '').slice(0, 6))}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#8B4513] focus:border-transparent outline-none tracking-[0.3em] text-center uppercase"
+                  placeholder="123456"
+                  required={needsOtp}
+                />
+                <p className="mt-2 text-[12px] text-gray-600">
+                  Откройте Google Authenticator или Яндекс.Аутентификатор и введите текущий 6-значный код.
+                </p>
+              </div>
+            )}
 
             {!isLogin && (
               <div>
@@ -259,14 +339,18 @@ export default function LoginPage({ onBack, onMenuClick, cartCount, totalBambico
           >
             <p className="text-[14px] text-gray-600">
               {isLogin ? 'Нет аккаунта?' : 'Уже есть аккаунт?'}
-              <button
-                onClick={() => {
-                  setIsLogin(!isLogin);
-                  setError('');
-                  setEmail('');
-                  setPassword('');
-                  setName('');
-                  setPhone('');
+                <button
+                  onClick={() => {
+                    setIsLogin(!isLogin);
+                    setError('');
+                    setIsLoading(false);
+                    setEmail('');
+                    setIdentifier('');
+                    setPassword('');
+                    setName('');
+                    setPhone('');
+                  setNeedsOtp(false);
+                  setOtpCode('');
                 }}
                 className="ml-2 text-[#8B4513] font-medium hover:underline"
               >

--- a/Shopping App/src/components/ProfilePage.tsx
+++ b/Shopping App/src/components/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth, TwoFactorProvider } from '../contexts/AuthContext';
+import { createOtpAuthUrl, generateTwoFactorSecret, verifyTotpToken } from '../utils/totp';
 
 interface ProfilePageProps {
   onBack: () => void;
@@ -11,13 +12,100 @@ interface ProfilePageProps {
 }
 
 export default function ProfilePage({ onBack, onMenuClick, cartCount, totalBambicoins, onLoginClick }: ProfilePageProps) {
-  const { user, logout, updateProfile } = useAuth();
+  const { user, logout, updateProfile, enableTwoFactor, disableTwoFactor } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
   const [editForm, setEditForm] = useState({
     name: user?.name || '',
     email: user?.email || '',
     phone: user?.phone || ''
   });
+  const [twoFactorInfo, setTwoFactorInfo] = useState('');
+  const [isTwoFactorSetupVisible, setIsTwoFactorSetupVisible] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<TwoFactorProvider>('google');
+  const [twoFactorSecret, setTwoFactorSecret] = useState<string | null>(null);
+  const [twoFactorOtp, setTwoFactorOtp] = useState('');
+  const [twoFactorOtpauth, setTwoFactorOtpauth] = useState<string | null>(null);
+
+  const getProviderLabel = (provider?: TwoFactorProvider) => {
+    switch (provider) {
+      case 'yandex':
+        return 'Яндекс.Аутентификатор';
+      case 'google':
+        return 'Google Authenticator';
+      default:
+        return 'приложение-аутентификатор';
+    }
+  };
+
+  const resetTwoFactorSetup = () => {
+    setIsTwoFactorSetupVisible(false);
+    setTwoFactorSecret(null);
+    setTwoFactorOtp('');
+    setTwoFactorOtpauth(null);
+  };
+
+  const handleCancelTwoFactor = () => {
+    resetTwoFactorSetup();
+    setTwoFactorInfo('Настройка двухфакторной аутентификации отменена.');
+  };
+
+  const handleStartTwoFactor = (provider: TwoFactorProvider) => {
+    if (!user) {
+      return;
+    }
+
+    setSelectedProvider(provider);
+    setTwoFactorInfo('');
+
+    try {
+      const secret = generateTwoFactorSecret();
+      const identifier = user.email || user.phone || user.name || 'Shopping App';
+      const otpauth = createOtpAuthUrl(secret, identifier, 'Shopping App', provider);
+
+      setTwoFactorSecret(secret);
+      setTwoFactorOtpauth(otpauth);
+      setTwoFactorOtp('');
+      setIsTwoFactorSetupVisible(true);
+    } catch (error) {
+      console.error('Не удалось сгенерировать секрет для 2FA:', error);
+      setTwoFactorInfo('Не удалось сгенерировать секретный ключ. Проверьте поддержку Web Crypto API в браузере.');
+      resetTwoFactorSetup();
+    }
+  };
+
+  const handleConfirmTwoFactor = async () => {
+    if (!twoFactorSecret) {
+      setTwoFactorInfo('Сначала сгенерируйте секретный ключ.');
+      return;
+    }
+
+    if (!twoFactorOtp.trim()) {
+      setTwoFactorInfo('Введите код подтверждения из приложения-аутентификатора.');
+      return;
+    }
+
+    try {
+      const isValid = await verifyTotpToken(twoFactorOtp.trim(), twoFactorSecret);
+
+      if (!isValid) {
+        setTwoFactorInfo('Неверный код. Проверьте приложение и попробуйте снова.');
+        return;
+      }
+
+      enableTwoFactor({ type: selectedProvider, secret: twoFactorSecret });
+      setTwoFactorInfo('Двухфакторная аутентификация успешно включена.');
+      resetTwoFactorSetup();
+    } catch (error) {
+      console.error('Не удалось проверить код двухфакторной аутентификации:', error);
+      setTwoFactorInfo('Не удалось проверить код. Убедитесь, что устройство поддерживает Web Crypto API.');
+    }
+  };
+
+  const handleDisableTwoFactor = () => {
+    disableTwoFactor();
+    setTwoFactorInfo('Двухфакторная аутентификация отключена.');
+    resetTwoFactorSetup();
+  };
 
   const handleEdit = () => {
     setIsEditing(true);
@@ -300,23 +388,140 @@ export default function ProfilePage({ onBack, onMenuClick, cartCount, totalBambi
               <h2 className="text-[20px] font-bold text-gray-900 mb-4">
                 Управление аккаунтом
               </h2>
-              
+
               <div className="space-y-3">
                 <button className="w-full bg-gray-50 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-100 transition-colors text-left">
                   📋 История заказов
                 </button>
-                
+
                 <button className="w-full bg-gray-50 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-100 transition-colors text-left">
                   ❤️ Избранные товары
                 </button>
-                
+
                 <button className="w-full bg-gray-50 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-100 transition-colors text-left">
                   🔔 Уведомления
                 </button>
-                
-                <button className="w-full bg-gray-50 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-100 transition-colors text-left">
-                  🛡️ Безопасность
-                </button>
+              </div>
+            </div>
+
+            <div>
+              <h2 className="text-[20px] font-bold text-gray-900 mb-4">
+                Безопасность
+              </h2>
+
+              <div className="bg-gray-50 rounded-lg p-4 space-y-4">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                  <div>
+                    <p className="text-[16px] font-semibold text-gray-900">Двухфакторная аутентификация</p>
+                    <p className="text-[14px] text-gray-600">
+                      {user.twoFactorEnabled
+                        ? `Включена (${getProviderLabel(user.twoFactorType)})`
+                        : 'Выключена'}
+                    </p>
+                  </div>
+                  <span className={`inline-flex items-center px-3 py-1 rounded-full text-[12px] font-medium ${user.twoFactorEnabled ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-700'}`}>
+                    {user.twoFactorEnabled ? 'Активна' : 'Выключена'}
+                  </span>
+                </div>
+
+                {twoFactorInfo && (
+                  <div className="bg-white border border-[#8B4513]/20 rounded-lg px-4 py-3 text-[14px] text-gray-700">
+                    {twoFactorInfo}
+                  </div>
+                )}
+
+                {user.twoFactorEnabled ? (
+                  <div className="space-y-3">
+                    <p className="text-[14px] text-gray-600">
+                      При входе после пароля потребуется код из {getProviderLabel(user.twoFactorType)}.
+                    </p>
+                    <button
+                      onClick={handleDisableTwoFactor}
+                      className="w-full bg-red-50 text-red-600 py-3 px-4 rounded-lg font-medium hover:bg-red-100 transition-colors border border-red-200"
+                    >
+                      Отключить двухфакторную аутентификацию
+                    </button>
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    <p className="text-[14px] text-gray-600">
+                      Подключите второй фактор через любимое приложение-аутентификатор. Поддерживаются Google Authenticator и Яндекс.Аутентификатор.
+                    </p>
+                    <div className="flex flex-col sm:flex-row gap-3">
+                      <button
+                        onClick={() => handleStartTwoFactor('google')}
+                        className="flex-1 bg-[#8B4513] text-white py-3 px-4 rounded-lg font-medium hover:bg-[#6B3410] transition-colors"
+                      >
+                        Google Authenticator
+                      </button>
+                      <button
+                        onClick={() => handleStartTwoFactor('yandex')}
+                        className="flex-1 bg-gray-200 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-300 transition-colors"
+                      >
+                        Яндекс.Аутентификатор
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {isTwoFactorSetupVisible && !user.twoFactorEnabled && (
+                  <div className="border border-[#8B4513]/20 rounded-lg p-4 bg-white space-y-4">
+                    <h3 className="text-[16px] font-semibold text-gray-900">
+                      Подключение ({getProviderLabel(selectedProvider)})
+                    </h3>
+                    <p className="text-[14px] text-gray-600">
+                      Добавьте аккаунт вручную и подтвердите 6-значным кодом из приложения.
+                    </p>
+
+                    <div className="bg-gray-100 rounded-lg p-3">
+                      <p className="text-[12px] text-gray-600">Секретный ключ для ввода вручную:</p>
+                      <p className="font-mono text-[16px] text-gray-900 break-all">{twoFactorSecret}</p>
+                    </div>
+
+                    {twoFactorOtpauth && (
+                      <p className="text-[12px] text-gray-600 break-all">
+                        Быстрое добавление (откроется соответствующее приложение):{' '}
+                        <a href={twoFactorOtpauth} className="text-[#8B4513] underline break-all">{twoFactorOtpauth}</a>
+                      </p>
+                    )}
+
+                    <ol className="list-decimal list-inside space-y-1 text-[12px] text-gray-600">
+                      <li>Откройте {getProviderLabel(selectedProvider)} и выберите добавление аккаунта.</li>
+                      <li>Введите секретный ключ вручную или воспользуйтесь ссылкой выше.</li>
+                      <li>Введите текущий код из приложения в поле ниже и подтвердите.</li>
+                    </ol>
+
+                    <div>
+                      <label className="block text-[14px] font-medium text-gray-700 mb-2">
+                        Код из приложения
+                      </label>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        value={twoFactorOtp}
+                        onChange={(e) => setTwoFactorOtp(e.target.value.replace(/[^0-9]/g, '').slice(0, 6))}
+                        className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#8B4513] focus:border-transparent outline-none tracking-[0.3em] text-center"
+                        placeholder="123456"
+                      />
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row gap-3">
+                      <button
+                        onClick={handleConfirmTwoFactor}
+                        className="flex-1 bg-[#8B4513] text-white py-3 px-4 rounded-lg font-medium hover:bg-[#6B3410] transition-colors"
+                      >
+                        Подтвердить код
+                      </button>
+                      <button
+                        onClick={handleCancelTwoFactor}
+                        className="flex-1 bg-gray-200 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-300 transition-colors"
+                      >
+                        Отмена
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
 

--- a/Shopping App/src/contexts/AuthContext.tsx
+++ b/Shopping App/src/contexts/AuthContext.tsx
@@ -1,4 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { verifyTotpToken } from '../utils/totp';
+
+export type TwoFactorProvider = 'google' | 'yandex';
 
 export interface User {
   id: string;
@@ -10,19 +13,126 @@ export interface User {
   joinDate: string;
   totalOrders: number;
   favoriteProducts: number[];
+  twoFactorEnabled: boolean;
+  twoFactorType?: TwoFactorProvider;
 }
 
 interface AuthContextType {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  login: (email: string, password: string) => Promise<boolean>;
+  login: (identifier: string, password: string, otpCode?: string) => Promise<LoginResult>;
   register: (email: string, password: string, name: string, phone?: string) => Promise<boolean>;
   logout: () => void;
   updateProfile: (updates: Partial<User>) => void;
   addToFavorites: (productId: number) => void;
   removeFromFavorites: (productId: number) => void;
+  enableTwoFactor: (options: { type: TwoFactorProvider; secret: string }) => void;
+  disableTwoFactor: () => void;
 }
+
+interface StoredUser extends Omit<User, 'twoFactorEnabled' | 'twoFactorType'> {
+  password: string;
+  twoFactorEnabled?: boolean;
+  twoFactorType?: TwoFactorProvider;
+  twoFactorSecret?: string | null;
+}
+
+interface LoginResult {
+  success: boolean;
+  requiresOtp?: boolean;
+  message?: string;
+}
+
+const DEMO_USER_ID = 'demo-user';
+
+const normalizeEmail = (value?: string) => (value || '').trim().toLowerCase();
+const normalizePhone = (value?: string) => (value || '').replace(/\D/g, '');
+
+const getStorage = (): Storage | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.error('Локальное хранилище недоступно:', error);
+    return null;
+  }
+};
+
+const loadRegisteredUsers = (): StoredUser[] => {
+  const storage = getStorage();
+
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(storage.getItem('registeredUsers') || '[]');
+  } catch (error) {
+    console.error('Ошибка при загрузке зарегистрированных пользователей:', error);
+    return [];
+  }
+};
+
+const saveRegisteredUsers = (users: StoredUser[]) => {
+  const storage = getStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  storage.setItem('registeredUsers', JSON.stringify(users));
+};
+
+const isDemoUser = (user: { id: string; email: string }) =>
+  user.id === DEMO_USER_ID || user.email === 'demo@example.com';
+
+const persistUserChanges = (userId: string, updates: Partial<StoredUser>) => {
+  const storage = getStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  const existingUsers = loadRegisteredUsers();
+  const userIndex = existingUsers.findIndex((stored) => stored.id === userId);
+
+  if (userIndex !== -1) {
+    existingUsers[userIndex] = { ...existingUsers[userIndex], ...updates };
+    saveRegisteredUsers(existingUsers);
+  }
+};
+
+const storedToUser = (stored: StoredUser): User => ({
+  id: stored.id,
+  email: stored.email,
+  name: stored.name,
+  phone: stored.phone,
+  avatar: stored.avatar,
+  bambicoins: stored.bambicoins ?? 0,
+  joinDate: stored.joinDate,
+  totalOrders: stored.totalOrders ?? 0,
+  favoriteProducts: Array.isArray(stored.favoriteProducts) ? stored.favoriteProducts : [],
+  twoFactorEnabled: !!stored.twoFactorEnabled,
+  twoFactorType: stored.twoFactorType,
+});
+
+const sanitizeUser = (data: any): User => ({
+  id: data?.id || '',
+  email: data?.email || '',
+  name: data?.name || '',
+  phone: data?.phone,
+  avatar: data?.avatar,
+  bambicoins: data?.bambicoins ?? 0,
+  joinDate: data?.joinDate || new Date().toISOString().split('T')[0],
+  totalOrders: data?.totalOrders ?? 0,
+  favoriteProducts: Array.isArray(data?.favoriteProducts) ? data.favoriteProducts : [],
+  twoFactorEnabled: !!data?.twoFactorEnabled,
+  twoFactorType: data?.twoFactorType,
+});
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -36,13 +146,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Загружаем данные пользователя из localStorage при инициализации
   useEffect(() => {
-    const savedUser = localStorage.getItem('user');
+    const storage = getStorage();
+    if (!storage) {
+      setIsLoading(false);
+      return;
+    }
+
+    const savedUser = storage.getItem('user');
     if (savedUser) {
       try {
-        setUser(JSON.parse(savedUser));
+        const parsed = JSON.parse(savedUser);
+        setUser(sanitizeUser(parsed));
       } catch (error) {
         console.error('Ошибка при загрузке данных пользователя:', error);
-        localStorage.removeItem('user');
+        storage.removeItem('user');
       }
     }
     setIsLoading(false);
@@ -50,91 +167,202 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Сохраняем данные пользователя в localStorage при изменении
   useEffect(() => {
+    const storage = getStorage();
+
+    if (!storage) {
+      return;
+    }
+
     if (user) {
-      localStorage.setItem('user', JSON.stringify(user));
+      storage.setItem('user', JSON.stringify(user));
     } else {
-      localStorage.removeItem('user');
+      storage.removeItem('user');
     }
   }, [user]);
 
-  const login = async (email: string, password: string): Promise<boolean> => {
+  const login = async (
+    identifier: string,
+    password: string,
+    otpCode?: string
+  ): Promise<LoginResult> => {
     setIsLoading(true);
-    
+
     try {
       // Имитация API запроса
       await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Простая проверка для демонстрации
-      if (email === 'demo@example.com' && password === 'demo123') {
-        const newUser: User = {
-          id: '1',
-          email: 'demo@example.com',
+
+      const trimmedIdentifier = identifier.trim();
+      const emailCandidate = trimmedIdentifier.includes('@') ? normalizeEmail(trimmedIdentifier) : '';
+      const phoneCandidate = normalizePhone(trimmedIdentifier);
+
+      // Проверка демо-аккаунта
+      const demoEmail = 'demo@example.com';
+      const demoPhone = normalizePhone('+7 (999) 123-45-67');
+      const matchesDemoEmail = emailCandidate === demoEmail;
+      const matchesDemoPhone = phoneCandidate && phoneCandidate === demoPhone;
+
+      if ((matchesDemoEmail || matchesDemoPhone) && password === 'demo123') {
+        let demoTwoFactorSettings: { enabled: boolean; type?: TwoFactorProvider; secret?: string } | null = null;
+
+        const storage = getStorage();
+
+        try {
+          demoTwoFactorSettings = JSON.parse(storage?.getItem('demoTwoFactorSettings') || 'null');
+        } catch (error) {
+          console.error('Ошибка при чтении настроек 2FA демо-пользователя:', error);
+        }
+
+        if (demoTwoFactorSettings?.enabled && demoTwoFactorSettings.secret) {
+          if (!otpCode) {
+            setIsLoading(false);
+            return {
+              success: false,
+              requiresOtp: true,
+              message: 'Введите одноразовый код из приложения-аутентификатора.'
+            };
+          }
+
+          const isValidOtp = await verifyTotpToken(otpCode, demoTwoFactorSettings.secret);
+
+          if (!isValidOtp) {
+            setIsLoading(false);
+            return {
+              success: false,
+              requiresOtp: true,
+              message: 'Неверный одноразовый код'
+            };
+          }
+        }
+
+        let demoProfileOverrides: Partial<User> | null = null;
+
+        const storage = getStorage();
+
+        try {
+          demoProfileOverrides = JSON.parse(storage?.getItem('demoUserProfile') || 'null');
+        } catch (error) {
+          console.error('Ошибка при чтении профиля демо-пользователя:', error);
+        }
+
+        const baseDemoUser = {
+          id: DEMO_USER_ID,
+          email: demoEmail,
           name: 'Демо Пользователь',
           phone: '+7 (999) 123-45-67',
           bambicoins: 500,
           joinDate: '2024-01-15',
           totalOrders: 3,
-          favoriteProducts: [1, 3, 5]
+          favoriteProducts: [1, 3, 5],
         };
+
+        const newUser = {
+          ...sanitizeUser({ ...baseDemoUser, ...demoProfileOverrides }),
+          twoFactorEnabled: !!demoTwoFactorSettings?.enabled,
+          twoFactorType: demoTwoFactorSettings?.type,
+        };
+
         setUser(newUser);
         setIsLoading(false);
-        return true;
+        return { success: true };
       }
-      
+
       // Проверяем существующих пользователей в localStorage
-      const existingUsers = JSON.parse(localStorage.getItem('registeredUsers') || '[]');
-      const foundUser = existingUsers.find((u: any) => u.email === email && u.password === password);
-      
+      const existingUsers = loadRegisteredUsers();
+      const foundUser = existingUsers.find((storedUser) => {
+        const matchesEmail = emailCandidate && normalizeEmail(storedUser.email) === emailCandidate;
+        const matchesPhone = phoneCandidate && normalizePhone(storedUser.phone) === phoneCandidate;
+
+        return (matchesEmail || matchesPhone) && storedUser.password === password;
+      });
+
       if (foundUser) {
-        const { password: _, ...userData } = foundUser;
+        if (foundUser.twoFactorEnabled && foundUser.twoFactorSecret) {
+          if (!otpCode) {
+            setIsLoading(false);
+            return {
+              success: false,
+              requiresOtp: true,
+              message: 'Введите одноразовый код из приложения-аутентификатора.'
+            };
+          }
+
+          const isValidOtp = await verifyTotpToken(otpCode, foundUser.twoFactorSecret);
+
+          if (!isValidOtp) {
+            setIsLoading(false);
+            return {
+              success: false,
+              requiresOtp: true,
+              message: 'Неверный одноразовый код'
+            };
+          }
+        }
+
+        const userData = storedToUser(foundUser);
         setUser(userData);
         setIsLoading(false);
-        return true;
+        return { success: true };
       }
-      
+
       setIsLoading(false);
-      return false;
+      return {
+        success: false,
+        message: 'Неверный email/телефон или пароль'
+      };
     } catch (error) {
       console.error('Ошибка при входе:', error);
       setIsLoading(false);
-      return false;
+      return {
+        success: false,
+        message: 'Не удалось выполнить вход. Попробуйте еще раз.'
+      };
     }
   };
 
   const register = async (email: string, password: string, name: string, phone?: string): Promise<boolean> => {
     setIsLoading(true);
-    
+
     try {
       // Имитация API запроса
       await new Promise(resolve => setTimeout(resolve, 1000));
-      
+
       // Проверяем, не существует ли уже пользователь с таким email
-      const existingUsers = JSON.parse(localStorage.getItem('registeredUsers') || '[]');
-      const userExists = existingUsers.some((u: any) => u.email === email);
-      
+      const existingUsers = loadRegisteredUsers();
+      const normalizedEmail = normalizeEmail(email);
+      const trimmedPhone = phone?.trim();
+      const normalizedPhone = trimmedPhone ? normalizePhone(trimmedPhone) : '';
+      const userExists = existingUsers.some((stored) => {
+        const sameEmail = normalizeEmail(stored.email) === normalizedEmail;
+        const samePhone = normalizedPhone && normalizePhone(stored.phone) === normalizedPhone;
+        return sameEmail || samePhone;
+      });
+
       if (userExists) {
         setIsLoading(false);
         return false;
       }
-      
-      const newUser = {
+
+      const newUser: StoredUser = {
         id: Date.now().toString(),
-        email,
+        email: email.trim(),
         password, // В реальном приложении пароль должен быть зашифрован
-        name,
-        phone,
+        name: name.trim(),
+        phone: trimmedPhone || undefined,
         bambicoins: 100, // Бонус за регистрацию
         joinDate: new Date().toISOString().split('T')[0],
         totalOrders: 0,
-        favoriteProducts: []
+        favoriteProducts: [],
+        twoFactorEnabled: false,
+        twoFactorType: undefined,
+        twoFactorSecret: null
       };
-      
+
       // Сохраняем пользователя в localStorage
       const updatedUsers = [...existingUsers, newUser];
-      localStorage.setItem('registeredUsers', JSON.stringify(updatedUsers));
-      
+      saveRegisteredUsers(updatedUsers);
+
       // Автоматически входим после регистрации
-      const { password: _, ...userData } = newUser;
+      const userData = storedToUser(newUser);
       setUser(userData);
       setIsLoading(false);
       return true;
@@ -151,24 +379,99 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const updateProfile = (updates: Partial<User>) => {
     if (user) {
-      setUser({ ...user, ...updates });
+      const normalizedUpdates: Partial<User> = {
+        ...updates,
+        email: updates.email?.trim(),
+        name: updates.name?.trim(),
+        phone: updates.phone?.trim(),
+      };
+
+      const updatedUser = sanitizeUser({ ...user, ...normalizedUpdates });
+      setUser(updatedUser);
+
+      if (isDemoUser(user)) {
+        const storage = getStorage();
+        storage?.setItem('demoUserProfile', JSON.stringify(updatedUser));
+      } else {
+        const storedUpdates: Partial<StoredUser> = {
+          email: normalizedUpdates.email ?? user.email,
+          name: normalizedUpdates.name ?? user.name,
+          phone: normalizedUpdates.phone ?? user.phone,
+          bambicoins: normalizedUpdates.bambicoins ?? user.bambicoins,
+          totalOrders: normalizedUpdates.totalOrders ?? user.totalOrders,
+          favoriteProducts: normalizedUpdates.favoriteProducts ?? user.favoriteProducts,
+        };
+
+        persistUserChanges(user.id, storedUpdates);
+      }
     }
   };
 
   const addToFavorites = (productId: number) => {
     if (user && !user.favoriteProducts.includes(productId)) {
-      setUser({
-        ...user,
-        favoriteProducts: [...user.favoriteProducts, productId]
-      });
+      const updatedFavorites = [...user.favoriteProducts, productId];
+      const updatedUser = { ...user, favoriteProducts: updatedFavorites };
+      setUser(updatedUser);
+
+      if (!isDemoUser(user)) {
+        persistUserChanges(user.id, { favoriteProducts: updatedFavorites });
+      }
     }
   };
 
   const removeFromFavorites = (productId: number) => {
     if (user) {
-      setUser({
-        ...user,
-        favoriteProducts: user.favoriteProducts.filter(id => id !== productId)
+      const updatedFavorites = user.favoriteProducts.filter(id => id !== productId);
+      const updatedUser = { ...user, favoriteProducts: updatedFavorites };
+      setUser(updatedUser);
+
+      if (!isDemoUser(user)) {
+        persistUserChanges(user.id, { favoriteProducts: updatedFavorites });
+      }
+    }
+  };
+
+  const enableTwoFactor = ({ type, secret }: { type: TwoFactorProvider; secret: string }) => {
+    if (!user) {
+      return;
+    }
+
+    const updatedUser = { ...user, twoFactorEnabled: true, twoFactorType: type };
+    setUser(updatedUser);
+
+    if (isDemoUser(user)) {
+      const storage = getStorage();
+      storage?.setItem(
+        'demoTwoFactorSettings',
+        JSON.stringify({ enabled: true, type, secret })
+      );
+      storage?.setItem('user', JSON.stringify(updatedUser));
+    } else {
+      persistUserChanges(user.id, {
+        twoFactorEnabled: true,
+        twoFactorType: type,
+        twoFactorSecret: secret,
+      });
+    }
+  };
+
+  const disableTwoFactor = () => {
+    if (!user) {
+      return;
+    }
+
+    const updatedUser = { ...user, twoFactorEnabled: false, twoFactorType: undefined };
+    setUser(updatedUser);
+
+    if (isDemoUser(user)) {
+      const storage = getStorage();
+      storage?.setItem('demoTwoFactorSettings', JSON.stringify({ enabled: false }));
+      storage?.setItem('user', JSON.stringify(updatedUser));
+    } else {
+      persistUserChanges(user.id, {
+        twoFactorEnabled: false,
+        twoFactorType: undefined,
+        twoFactorSecret: null,
       });
     }
   };
@@ -182,7 +485,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     logout,
     updateProfile,
     addToFavorites,
-    removeFromFavorites
+    removeFromFavorites,
+    enableTwoFactor,
+    disableTwoFactor,
   };
 
   return (

--- a/Shopping App/src/utils/totp.ts
+++ b/Shopping App/src/utils/totp.ts
@@ -1,0 +1,136 @@
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+const getCrypto = (): Crypto => {
+  const cryptoObj = (globalThis as any)?.crypto as Crypto | undefined;
+
+  if (!cryptoObj) {
+    throw new Error('Web Crypto API недоступен в данном окружении.');
+  }
+
+  return cryptoObj;
+};
+
+const base32ToBytes = (input: string): Uint8Array => {
+  const cleaned = input.toUpperCase().replace(/[^A-Z2-7]/g, '');
+  let bits = '';
+
+  for (const char of cleaned) {
+    const value = BASE32_ALPHABET.indexOf(char);
+
+    if (value === -1) {
+      throw new Error(`Недопустимый символ base32: ${char}`);
+    }
+
+    bits += value.toString(2).padStart(5, '0');
+  }
+
+  const bytes: number[] = [];
+
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i + 8), 2));
+  }
+
+  return new Uint8Array(bytes);
+};
+
+const counterToBuffer = (counter: number): ArrayBuffer => {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+
+  const high = Math.floor(counter / 0x100000000);
+  const low = counter % 0x100000000;
+
+  view.setUint32(0, high);
+  view.setUint32(4, low);
+
+  return buffer;
+};
+
+const generateHmac = async (secret: string, counter: number): Promise<Uint8Array> => {
+  const cryptoObj = getCrypto();
+  const keyBytes = base32ToBytes(secret);
+  const key = await cryptoObj.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'HMAC', hash: 'SHA-1' },
+    false,
+    ['sign']
+  );
+
+  const buffer = counterToBuffer(counter);
+  const signature = await cryptoObj.subtle.sign('HMAC', key, buffer);
+
+  return new Uint8Array(signature);
+};
+
+const hotp = async (secret: string, counter: number, digits = 6): Promise<string> => {
+  const hmac = await generateHmac(secret, counter);
+  const offset = hmac[hmac.length - 1] & 0xf;
+
+  const binary =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+
+  const otp = binary % 10 ** digits;
+
+  return otp.toString().padStart(digits, '0');
+};
+
+export const generateTwoFactorSecret = (length = 32): string => {
+  const cryptoObj = getCrypto();
+  const randomBytes = new Uint8Array(length);
+  cryptoObj.getRandomValues(randomBytes);
+
+  return Array.from(randomBytes)
+    .map((value) => BASE32_ALPHABET[value % BASE32_ALPHABET.length])
+    .join('');
+};
+
+export const createOtpAuthUrl = (
+  secret: string,
+  accountName: string,
+  issuer: string,
+  provider?: 'google' | 'yandex'
+): string => {
+  const labelAccount = provider === 'yandex' ? `${accountName} (Yandex)` : accountName;
+  const label = `${issuer}:${labelAccount}`;
+  const encodedLabel = encodeURIComponent(label);
+  const encodedIssuer = encodeURIComponent(issuer);
+  const encodedSecret = encodeURIComponent(secret.replace(/\s+/g, ''));
+
+  return `otpauth://totp/${encodedLabel}?secret=${encodedSecret}&issuer=${encodedIssuer}&algorithm=SHA1&digits=6&period=30`;
+};
+
+export const verifyTotpToken = async (
+  token: string,
+  secret: string,
+  options: { window?: number; step?: number; digits?: number } = {}
+): Promise<boolean> => {
+  const { window = 1, step = 30, digits = 6 } = options;
+  const sanitizedToken = token.replace(/\s+/g, '');
+
+  if (!new RegExp(`^\\d{${digits}}$`).test(sanitizedToken)) {
+    return false;
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const counter = Math.floor(timestamp / step);
+
+  for (let offset = -window; offset <= window; offset += 1) {
+    const currentCounter = counter + offset;
+
+    if (currentCounter < 0) {
+      continue;
+    }
+
+    const expected = await hotp(secret, currentCounter, digits);
+
+    if (expected === sanitizedToken) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Summary
- guard all auth-context persistence helpers behind safe localStorage detection, trim profile updates, and prevent duplicate registration by phone or email
- improve login screen messaging by logging caught errors, handling demo login failures safely, and resetting UI state when switching between login and registration
- ensure generated otpauth links encode shared secrets correctly for authenticator apps

## Testing
- npm run build *(fails: missing Vite binary because npm install is blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e117d0ed70832ab4bfd46719d6058c